### PR TITLE
Reduce the number of threads

### DIFF
--- a/app/src/main/java/com/sh1r0/noveldroid/NovelUtils.java
+++ b/app/src/main/java/com/sh1r0/noveldroid/NovelUtils.java
@@ -16,7 +16,7 @@ import java.util.zip.ZipFile;
 
 public class NovelUtils {
 	public static final String DEFAULT_NAMING_RULE = "/n";
-	public static final int MAX_THREAD_NUM = 4;
+	public static final int MAX_THREAD_NUM = 2;
 	public static final String APP_DIR = Environment.getExternalStorageDirectory().getAbsolutePath() + "/NovelDroid/";
 	public static final String TEMP_DIR = APP_DIR + "temp/";
 	private static NovelUtils novelUtils;


### PR DESCRIPTION
Related to issue #8.

In my test, if I try to download a short novel. It will success. But if the number of pages of article is longer. It will fail. I think the parser is correct but has been limited by server. Reduce the number of threads, we got it!

Thanks.